### PR TITLE
Allow dealer ID in params

### DIFF
--- a/app/controllers/admin/sales_territories_controller.rb
+++ b/app/controllers/admin/sales_territories_controller.rb
@@ -49,7 +49,7 @@ module Admin
     end
 
     def sales_territory_params
-      params.require(:sales_territory).permit(:name, :dealer, :sales_office_id, :sales_region_id)
+      params.require(:sales_territory).permit(:name, :dealer_id, :sales_office_id, :sales_region_id)
     end
 
   end


### PR DESCRIPTION
Assigning a dealer to a sales territory was not working because of a typo in the params hash.

Fixes #

## Proposed Changes

-
-
-
